### PR TITLE
Misleading value in the example

### DIFF
--- a/eksempel2_lokus_med_hint.md
+++ b/eksempel2_lokus_med_hint.md
@@ -217,7 +217,7 @@ Nr.|Comment|Who (actor)|Did (verb)|What (object)|
     },
     "result": {
         "duration": "PT2M45S",
-        "response": "B,C,D",
+        "response": "A,B,C",
         "success": true,
         "score": {
             "min": 0.0,


### PR DESCRIPTION
Before, there was value 'B,C,D" that matches the pattern completly, so the score for it should be {min:0, max:3, raw: 3, scaled: 1}, to match the score of 0.6667, it should be an answer that matches only 2 of 3 correct answers :)